### PR TITLE
Remove unwanted node install step as node v10 installed by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ update the AWS CLI
 pip install --user --upgrade awscli
 ```
 
-install and use Node.js v8.10 (to match AWS Lambda)
-
-```sh
-nvm install v8.11.0 nvm alias default v8.11.0
-```
-
 install the AWS Amplify CLI
 
 ```sh


### PR DESCRIPTION
AWS presenter during a workshop advised that this step is no longer required as Node v10 is installed by default.

Following this old step installing an older version of Node mucks everything up as it gets confused about which version of Node to use.